### PR TITLE
Fix fraction addition and mult associativity

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,17 +1,28 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Eff.Console (log)
 import Test.QuickCheck.Laws.Data.Eq
 import Test.QuickCheck.Laws.Data.Ord
 import Test.QuickCheck.Laws.Data.Semiring
 import Test.QuickCheck.Laws.Data.Ring
-import Type.Proxy (Proxy(..))
 import Data.HugeNum
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import Control.Monad.Eff.Random (RANDOM)
+import Type.Proxy (Proxy(..))
 
 prxHugeNum :: Proxy HugeNum
 prxHugeNum = Proxy
 
+main :: forall eff.
+  Eff
+    ( console :: CONSOLE
+    , random :: RANDOM
+    , err :: EXCEPTION
+    | eff
+    )
+    Unit
 main = do
   log "Checking HugeNum instances...\n"
   checkEq prxHugeNum


### PR DESCRIPTION
This fixes plus and times operations of HugeNums with digits.

Also fixed `fractionalPart`, which didn't adjust for decimal places. You can manually check this fix with the `fractionalPart (fromNumber 184.01)` test case.

Future improvements:
- This arbitrary instance doesn't produce negative numbers.
- The performance of this multiplication algorithm is pretty abysmal. I have no any ideas for improvement, however.