### PR TITLE
Fix HugeNum comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes (😱!!!):
 New features:
 
 Bugfixes:
+- Fixed comparing negative `HugeNum` values and `HugeInt.toInt` returning `Nothing` for negative values ([#10](https://github.com/purescript-contrib/purescript-precise/issues/10))
 
 Other improvements:
 

--- a/src/Data/HugeNum.purs
+++ b/src/Data/HugeNum.purs
@@ -102,8 +102,8 @@ compareHugeNum :: HugeNum -> HugeNum -> Ordering
 compareHugeNum x@(HugeNum r1) y@(HugeNum r2)
   | r1.sign < r2.sign = LT
   | r1.sign > r2.sign = GT
-  | r1.decimal > r2.decimal = GT
-  | r1.decimal < r2.decimal = LT
+  | r1.decimal > r2.decimal = if r1.sign == Minus then LT else GT
+  | r1.decimal < r2.decimal = if r1.sign == Minus then GT else LT
   | x == y = EQ
   | otherwise = z where
     dec = r1.decimal

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,13 +2,16 @@ module Test.Main where
 
 import Prelude
 
-import Data.HugeNum (HugeNum)
-import Data.HugeNum.Gen (genHugeNum)
 import Data.HugeInt (HugeInt)
+import Data.HugeInt as HI
 import Data.HugeInt.Gen (genHugeInt)
+import Data.HugeNum (HugeNum)
+import Data.HugeNum as HN
+import Data.HugeNum.Gen (genHugeNum)
+import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Console (log)
-import Test.QuickCheck (class Arbitrary)
+import Test.QuickCheck (class Arbitrary, quickCheck)
 import Test.QuickCheck.Laws.Data.Eq (checkEq)
 import Test.QuickCheck.Laws.Data.Ord (checkOrd)
 import Test.QuickCheck.Laws.Data.Ring (checkRing)
@@ -55,3 +58,13 @@ main = do
   checkOrd prxHugeInt
   checkSemiring prxHugeInt
   checkRing prxHugeInt
+  log "Checking from/to Num...\n"
+  quickCheck toFromNumIsIdentity
+  log "Checking from/to Int...\n"
+  quickCheck toFromIntIsIdentity
+
+toFromNumIsIdentity :: Number -> Boolean
+toFromNumIsIdentity n = HN.toNumber (HN.fromNumber n) == n
+
+toFromIntIsIdentity :: Int -> Boolean
+toFromIntIsIdentity n = HI.toInt (HI.fromInt n) == Just n


### PR DESCRIPTION
**Description of the change**
This PR fixes comparing negative numbers. This was also causing the problem mentioned in #10 because `HugeInt.toInt` was using `HugeNum` comparison internally.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- ~Updated or added relevant documentation in the README and/or documentation directory~
- [x] Added a test for the contribution (if applicable)
